### PR TITLE
Add Sounding-style JSDoc type surface

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "maxNodeModuleJsDepth": 0,
+    "strict": false,
+    "skipLibCheck": true
+  },
+  "include": ["lib/**/*.js", "typecheck/**/*.js"],
+  "exclude": ["node_modules"]
+}

--- a/lib/core/executor.js
+++ b/lib/core/executor.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * core/executor.js
  *
@@ -7,21 +9,28 @@
 const { spawn } = require('child_process')
 const fs = require('fs')
 const path = require('path')
+const { getGlobalSails } = require('./global-sails')
+
+/** @typedef {import('../types').AnyRecord} AnyRecord */
+/** @typedef {import('../types').QuestExecutableJob} QuestExecutableJob */
+/** @typedef {import('../types').QuestExecutionResult} QuestExecutionResult */
+/** @typedef {import('../types').QuestExecutorContext} QuestExecutorContext */
 
 /**
  * Execute a job via `sails run`
  * @param {String} name - Job name
- * @param {Object} job - Job configuration
- * @param {Object} customInputs - Custom input values
- * @param {Object} context - Execution context with running map, config, etc
- * @returns {Promise} Resolves when job completes
+ * @param {QuestExecutableJob} job - Job configuration
+ * @param {AnyRecord} [customInputs] - Custom input values
+ * @param {QuestExecutorContext} [context] - Execution context with running map, config, etc
+ * @returns {Promise<QuestExecutionResult>} Resolves when job completes
  */
 async function executeJob(name, job, customInputs = {}, context = {}) {
   const { running = new Map(), config = {} } = context
 
   // Check if job is already running (and overlapping is disabled)
   if (job.withoutOverlapping && running.has(name)) {
-    if (global.sails) {
+    const sails = getGlobalSails()
+    if (sails) {
       sails.log.warn(`Job "${name}" is already running, skipping...`)
     }
     return { skipped: true, reason: 'already_running' }
@@ -29,23 +38,29 @@ async function executeJob(name, job, customInputs = {}, context = {}) {
 
   // Don't run if paused
   if (job.paused) {
-    if (global.sails) {
+    const sails = getGlobalSails()
+    if (sails) {
       sails.log.verbose(`Job "${name}" is paused, skipping...`)
     }
     return { skipped: true, reason: 'paused' }
   }
 
-  if (global.sails) {
+  const sails = getGlobalSails()
+  if (sails) {
     sails.log.info(`Running job: ${name}`)
   }
 
   running.set(name, Date.now())
 
   // Merge inputs with priority: jobInputs < scriptInputs < customInputs
-  const inputs = { ...job.inputs, ...job.scriptInputs, ...customInputs }
+  const inputs = {
+    ...(job.inputs || {}),
+    ...(job.scriptInputs || {}),
+    ...customInputs
+  }
 
   // Emit job start event
-  if (global.sails) {
+  if (sails) {
     sails.emit('quest:job:start', {
       name,
       inputs,
@@ -74,7 +89,7 @@ async function executeJob(name, job, customInputs = {}, context = {}) {
       const error = new Error(
         `Job "${name}" not found. Please check that the script exists at ${scriptsDir}/${name}.js`
       )
-      if (global.sails) {
+      if (sails) {
         sails.log.error(error.message)
         sails.emit('quest:job:error', {
           name,
@@ -94,12 +109,12 @@ async function executeJob(name, job, customInputs = {}, context = {}) {
     })
 
     child.on('exit', (code) => {
-      const startTime = running.get(name)
+      const startTime = /** @type {number} */ (running.get(name))
       const duration = Date.now() - startTime
       running.delete(name)
 
       if (code === 0) {
-        if (global.sails) {
+        if (sails) {
           sails.log.info(`Job "${name}" completed successfully`)
 
           // Emit success event
@@ -115,7 +130,7 @@ async function executeJob(name, job, customInputs = {}, context = {}) {
       } else {
         const error = new Error(`Job "${name}" exited with code ${code}`)
 
-        if (global.sails) {
+        if (sails) {
           sails.log.error(error)
 
           // Emit error event
@@ -140,7 +155,7 @@ async function executeJob(name, job, customInputs = {}, context = {}) {
       const duration = Date.now() - startTime
       running.delete(name)
 
-      if (global.sails) {
+      if (sails) {
         sails.log.error(`Job "${name}" failed to start:`, err)
 
         // Emit error event
@@ -164,8 +179,8 @@ async function executeJob(name, job, customInputs = {}, context = {}) {
 /**
  * Build command arguments for sails run
  * @param {String} scriptName - Name of the script
- * @param {Object} inputs - Input values
- * @returns {Array} Command arguments
+ * @param {AnyRecord} [inputs] - Input values
+ * @returns {string[]} Command arguments
  */
 function buildCommandArgs(scriptName, inputs = {}) {
   const args = ['run', scriptName]

--- a/lib/core/global-sails.js
+++ b/lib/core/global-sails.js
@@ -1,0 +1,16 @@
+// @ts-check
+
+/** @typedef {import('../types').QuestSailsApp} QuestSailsApp */
+
+/**
+ * Resolve the ambient Sails app when core modules run outside the hook factory.
+ *
+ * @returns {QuestSailsApp | undefined}
+ */
+function getGlobalSails() {
+  return /** @type {{ sails?: QuestSailsApp }} */ (global).sails
+}
+
+module.exports = {
+  getGlobalSails
+}

--- a/lib/core/job-control.js
+++ b/lib/core/job-control.js
@@ -1,8 +1,21 @@
+// @ts-check
+
 /**
  * core/job-control.js
  *
  * Functions for controlling job lifecycle (start, stop, pause, resume)
  */
+
+const { getGlobalSails } = require('./global-sails')
+
+/** @typedef {import('../types').AnyRecord} AnyRecord */
+/** @typedef {import('../types').QuestExecutionResult} QuestExecutionResult */
+/** @typedef {import('../types').QuestJobNameInput} QuestJobNameInput */
+/** @typedef {import('../types').QuestJobsMap} QuestJobsMap */
+/** @typedef {import('../types').QuestRunContext} QuestRunContext */
+/** @typedef {import('../types').QuestScheduleContext} QuestScheduleContext */
+/** @typedef {import('../types').QuestStartContext} QuestStartContext */
+/** @typedef {import('../types').QuestStopContext} QuestStopContext */
 
 // setTimeout uses a 32-bit signed integer internally.
 // Delays larger than this overflow and fire immediately (~1ms), causing infinite loops.
@@ -11,19 +24,23 @@ const MAX_SAFE_TIMEOUT = 2_147_483_647 // 2^31 - 1, ~24.8 days
 /**
  * Schedule a job to run at its next scheduled time
  * @param {String} name - Job name
- * @param {Object} context - Context with jobs, timers maps and helper functions
+ * @param {QuestScheduleContext} [context] - Context with jobs, timers maps and helper functions
  */
 function scheduleJob(name, context = {}) {
-  const {
-    jobs = new Map(),
-    timers = new Map(),
-    getNextRunTime,
-    executeJob
-  } = context
+  const { jobs = new Map(), timers = new Map() } = context
+  const getNextRunTime =
+    /** @type {NonNullable<QuestScheduleContext['getNextRunTime']>} */ (
+      context.getNextRunTime
+    )
+  const executeJob =
+    /** @type {NonNullable<QuestScheduleContext['executeJob']>} */ (
+      context.executeJob
+    )
 
   const job = jobs.get(name)
   if (!job) {
-    if (global.sails) {
+    const sails = getGlobalSails()
+    if (sails) {
       sails.log.warn(`Job "${name}" not found in jobs Map`)
     }
     return
@@ -35,7 +52,8 @@ function scheduleJob(name, context = {}) {
   // Get the next run time
   const nextRun = getNextRunTime(job)
   if (!nextRun) {
-    if (global.sails) {
+    const sails = getGlobalSails()
+    if (sails) {
       sails.log.warn(
         `Job "${name}" has no valid schedule (interval: ${job.interval}, cron: ${job.cron}, timeout: ${job.timeout})`
       )
@@ -48,7 +66,8 @@ function scheduleJob(name, context = {}) {
   // If delay is negative (past time), run immediately
   if (delay <= 0) {
     executeJob(name).catch((err) => {
-      if (global.sails) {
+      const sails = getGlobalSails()
+      if (sails) {
         sails.log.error(`Error running job "${name}":`, err)
       }
     })
@@ -69,7 +88,8 @@ function scheduleJob(name, context = {}) {
 
     timers.set(name, timer)
 
-    if (global.sails) {
+    const sails = getGlobalSails()
+    if (sails) {
       sails.log.verbose(
         `Job "${name}" scheduled for ${nextRun.toISOString()} (delay exceeds 24.8d, re-checking later)`
       )
@@ -80,7 +100,8 @@ function scheduleJob(name, context = {}) {
   // Set timer for the next execution
   const timer = setTimeout(() => {
     executeJob(name).catch((err) => {
-      if (global.sails) {
+      const sails = getGlobalSails()
+      if (sails) {
         sails.log.error(`Error running job "${name}":`, err)
       }
     })
@@ -93,7 +114,8 @@ function scheduleJob(name, context = {}) {
 
   timers.set(name, timer)
 
-  if (global.sails) {
+  const sails = getGlobalSails()
+  if (sails) {
     sails.log.verbose(`Job "${name}" scheduled for ${nextRun.toISOString()}`)
   }
 }
@@ -101,7 +123,7 @@ function scheduleJob(name, context = {}) {
 /**
  * Stop a single job
  * @param {String} name - Job name
- * @param {Object} context - Context with timers map
+ * @param {QuestStopContext} [context] - Context with timers map
  */
 function stopJob(name, context = {}) {
   const { timers = new Map() } = context
@@ -111,7 +133,8 @@ function stopJob(name, context = {}) {
     clearTimeout(timer)
     clearInterval(timer)
     timers.delete(name)
-    if (global.sails) {
+    const sails = getGlobalSails()
+    if (sails) {
       sails.log.verbose(`Job "${name}" stopped`)
     }
   }
@@ -119,11 +142,16 @@ function stopJob(name, context = {}) {
 
 /**
  * Start scheduling jobs
- * @param {String|Array} jobNames - Job names to start (optional)
- * @param {Object} context - Context with jobs map and scheduleJob function
+ * @param {QuestJobNameInput} jobNames - Job names to start (optional)
+ * @param {QuestStartContext} [context] - Context with jobs map and scheduleJob function
+ * @returns {Promise<void>}
  */
 async function startJobs(jobNames, context = {}) {
-  const { jobs = new Map(), scheduleJob } = context
+  const { jobs = new Map() } = context
+  const scheduleJob =
+    /** @type {NonNullable<QuestStartContext['scheduleJob']>} */ (
+      context.scheduleJob
+    )
 
   const names = !jobNames
     ? Array.from(jobs.keys())
@@ -138,8 +166,9 @@ async function startJobs(jobNames, context = {}) {
 
 /**
  * Stop scheduling jobs
- * @param {String|Array} jobNames - Job names to stop (optional)
- * @param {Object} context - Context with jobs and timers maps
+ * @param {QuestJobNameInput} jobNames - Job names to stop (optional)
+ * @param {QuestStopContext} [context] - Context with jobs and timers maps
+ * @returns {void}
  */
 function stopJobs(jobNames, context = {}) {
   const { jobs = new Map(), timers = new Map() } = context
@@ -157,12 +186,16 @@ function stopJobs(jobNames, context = {}) {
 
 /**
  * Run jobs immediately
- * @param {String|Array} jobNames - Job names to run
- * @param {Object} inputs - Custom inputs
- * @param {Object} context - Context with executeJob function
+ * @param {QuestJobNameInput} jobNames - Job names to run
+ * @param {AnyRecord} [inputs] - Custom inputs
+ * @param {QuestRunContext} [context] - Context with executeJob function
+ * @returns {Promise<QuestExecutionResult[]>}
  */
 async function runJobs(jobNames, inputs, context = {}) {
-  const { jobs = new Map(), executeJob } = context
+  const { jobs = new Map() } = context
+  const executeJob = /** @type {NonNullable<QuestRunContext['executeJob']>} */ (
+    context.executeJob
+  )
 
   const names = !jobNames
     ? Array.from(jobs.keys())
@@ -177,7 +210,8 @@ async function runJobs(jobNames, inputs, context = {}) {
 /**
  * Pause a job
  * @param {String} name - Job name
- * @param {Map} jobs - Jobs map
+ * @param {QuestJobsMap} [jobs] - Jobs map
+ * @returns {boolean}
  */
 function pauseJob(name, jobs = new Map()) {
   const job = jobs.get(name)
@@ -191,7 +225,8 @@ function pauseJob(name, jobs = new Map()) {
 /**
  * Resume a job
  * @param {String} name - Job name
- * @param {Map} jobs - Jobs map
+ * @param {QuestJobsMap} [jobs] - Jobs map
+ * @returns {boolean}
  */
 function resumeJob(name, jobs = new Map()) {
   const job = jobs.get(name)

--- a/lib/core/loader.js
+++ b/lib/core/loader.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * core/loader.js
  *
@@ -6,13 +8,24 @@
 
 const path = require('path')
 const includeAll = require('include-all')
+const { getGlobalSails } = require('./global-sails')
+
+/** @typedef {import('../types').AnyRecord} AnyRecord */
+/** @typedef {import('../types').QuestConfig} QuestConfig */
+/** @typedef {import('../types').QuestJob} QuestJob */
+/** @typedef {import('../types').QuestJobDefinition} QuestJobDefinition */
+/** @typedef {import('../types').QuestJobsMap} QuestJobsMap */
+/** @typedef {import('../types').QuestMachineInputs} QuestMachineInputs */
+/** @typedef {import('../types').QuestScriptDefinition} QuestScriptDefinition */
+/** @typedef {import('../types').QuestTimersMap} QuestTimersMap */
 
 /**
  * Extract default values from a script's inputs schema
- * @param {Object} inputs - Script's inputs definition (Sails machine format)
- * @returns {Object} Object with input names and their defaultsTo values
+ * @param {QuestMachineInputs | null | undefined} inputs - Script's inputs definition (Sails machine format)
+ * @returns {AnyRecord} Object with input names and their defaultsTo values
  */
 function extractScriptInputDefaults(inputs) {
+  /** @type {AnyRecord} */
   const defaults = {}
   if (!inputs || typeof inputs !== 'object') return defaults
 
@@ -26,9 +39,9 @@ function extractScriptInputDefaults(inputs) {
 
 /**
  * Load jobs from scripts directory and config
- * @param {Object} config - Quest configuration
- * @param {Map} jobs - Jobs map to populate
- * @returns {Promise<Map>} Populated jobs map
+ * @param {QuestConfig} config - Quest configuration
+ * @param {QuestJobsMap} [jobs] - Jobs map to populate
+ * @returns {Promise<QuestJobsMap>} Populated jobs map
  */
 async function loadJobs(config, jobs = new Map()) {
   // First, load scripts from the scripts directory
@@ -36,17 +49,21 @@ async function loadJobs(config, jobs = new Map()) {
   const appPath = config.appPath || process.cwd()
   const fullPath = path.resolve(appPath, scriptsDir)
 
+  /** @type {Record<string, QuestScriptDefinition>} */
   let scripts = {}
 
   try {
-    scripts = includeAll({
-      dirname: fullPath,
-      filter: /(.+)\.js$/,
-      excludeDirs: /^\.(git|svn)$/,
-      flatten: true
-    })
+    scripts = /** @type {Record<string, QuestScriptDefinition>} */ (
+      includeAll({
+        dirname: fullPath,
+        filter: /(.+)\.js$/,
+        excludeDirs: /^\.(git|svn)$/,
+        flatten: true
+      })
+    )
   } catch (e) {
-    if (global.sails) {
+    const sails = getGlobalSails()
+    if (sails) {
       sails.log.verbose('No scripts directory found, skipping script jobs')
     }
   }
@@ -57,18 +74,22 @@ async function loadJobs(config, jobs = new Map()) {
 
     for (const jobDef of config.jobs) {
       // Handle string shorthand (just job name)
+      /** @type {QuestJobDefinition} */
       const job = typeof jobDef === 'string' ? { name: jobDef } : jobDef
+      const jobName = job.name
 
       // Check for duplicate job names in config
-      if (configJobNames.has(job.name)) {
+      if (jobName && configJobNames.has(jobName)) {
         throw new Error(
-          `Duplicate job name "${job.name}" in config/quest.js. Each job must have a unique name.`
+          `Duplicate job name "${jobName}" in config/quest.js. Each job must have a unique name.`
         )
       }
-      configJobNames.add(job.name)
+      if (jobName) {
+        configJobNames.add(jobName)
+      }
 
       // Try to get script inputs if the script exists
-      const scriptDef = scripts[job.name]
+      const scriptDef = jobName ? scripts[jobName] : undefined
       if (scriptDef && !job.scriptInputs) {
         job.scriptInputs = extractScriptInputDefaults(scriptDef.inputs)
       }
@@ -92,13 +113,14 @@ async function loadJobs(config, jobs = new Map()) {
     const existingJob = jobs.get(jobName)
 
     // Merge: config as base, script quest config takes priority
+    /** @type {QuestJobDefinition} */
     const jobDef = {
       name: jobName,
       friendlyName: scriptDef.friendlyName,
       description: scriptDef.description,
       // Preserve config's withoutOverlapping if script doesn't specify
       withoutOverlapping: existingJob?.withoutOverlapping,
-      inputs: { ...existingJob?.inputs, ...questConfig.inputs },
+      inputs: { ...(existingJob?.inputs || {}), ...(questConfig.inputs || {}) },
       ...questConfig,
       scriptInputs
     }
@@ -111,21 +133,23 @@ async function loadJobs(config, jobs = new Map()) {
 
 /**
  * Add a job definition to the jobs Map
- * @param {Object} jobDef - Job definition
- * @param {Map} jobs - Jobs map
- * @param {Object} config - Quest configuration
- * @returns {Object} Normalized job
+ * @param {QuestJobDefinition} jobDef - Job definition
+ * @param {QuestJobsMap} [jobs] - Jobs map
+ * @param {QuestConfig} [config] - Quest configuration
+ * @returns {QuestJob | null} Normalized job
  */
 function addJobDefinition(jobDef, jobs = new Map(), config = {}) {
   const name = jobDef.name
   if (!name) {
-    if (global.sails) {
+    const sails = getGlobalSails()
+    if (sails) {
       sails.log.warn('Job definition missing name, skipping:', jobDef)
     }
     return null
   }
 
   // Parse and normalize the job definition
+  /** @type {QuestJob} */
   const job = {
     name,
     friendlyName: jobDef.friendlyName || name,
@@ -151,7 +175,8 @@ function addJobDefinition(jobDef, jobs = new Map(), config = {}) {
 
   jobs.set(name, job)
 
-  if (global.sails) {
+  const sails = getGlobalSails()
+  if (sails) {
     const schedule = {}
     if (job.interval !== undefined) schedule.interval = job.interval
     if (job.cron !== undefined) schedule.cron = job.cron
@@ -165,8 +190,8 @@ function addJobDefinition(jobDef, jobs = new Map(), config = {}) {
 /**
  * Remove a job from the jobs map
  * @param {String} name - Job name
- * @param {Map} jobs - Jobs map
- * @param {Map} timers - Timers map
+ * @param {QuestJobsMap} [jobs] - Jobs map
+ * @param {QuestTimersMap} [timers] - Timers map
  * @returns {Boolean} Success
  */
 function removeJob(name, jobs = new Map(), timers = new Map()) {
@@ -181,7 +206,8 @@ function removeJob(name, jobs = new Map(), timers = new Map()) {
   // Remove from jobs map
   const existed = jobs.delete(name)
 
-  if (existed && global.sails) {
+  const sails = getGlobalSails()
+  if (existed && sails) {
     sails.log.verbose(`Job "${name}" removed`)
   }
 

--- a/lib/core/scheduler.js
+++ b/lib/core/scheduler.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * core/scheduler.js
  *
@@ -7,11 +9,16 @@
 const later = require('@breejs/later')
 const humanInterval = require('human-interval')
 const { CronExpressionParser } = require('cron-parser')
+const { getGlobalSails } = require('./global-sails')
+
+/** @typedef {import('../types').QuestConfig} QuestConfig */
+/** @typedef {import('../types').QuestJobDefinition} QuestJobDefinition */
+/** @typedef {import('../types').QuestTimeout} QuestTimeout */
 
 /**
  * Parse various schedule formats and return next run time
- * @param {Object} job - Job configuration
- * @param {Object} config - Quest configuration
+ * @param {QuestJobDefinition} job - Job configuration
+ * @param {QuestConfig} [config] - Quest configuration
  * @returns {Date|null} Next run time or null if invalid
  */
 function getNextRunTime(job, config = {}) {
@@ -36,10 +43,11 @@ function getNextRunTime(job, config = {}) {
       const interval = CronExpressionParser.parse(job.cron, options)
       return interval.next().toDate()
     } catch (err) {
-      if (global.sails) {
+      const sails = getGlobalSails()
+      if (sails) {
         sails.log.error(
           `Invalid cron expression for job "${job.name}": ${job.cron}`,
-          err.message
+          err instanceof Error ? err.message : err
         )
       }
       return null
@@ -51,7 +59,8 @@ function getNextRunTime(job, config = {}) {
     const nextTime = parseInterval(job.interval, now)
     if (nextTime) return nextTime
 
-    if (global.sails) {
+    const sails = getGlobalSails()
+    if (sails) {
       sails.log.error(`Invalid interval for job "${job.name}": ${job.interval}`)
     }
     return null
@@ -95,6 +104,7 @@ function parseInterval(intervalStr, fromDate = new Date()) {
   if (everyMatch) {
     const amount = parseInt(everyMatch[1])
     const unit = everyMatch[2].replace(/s$/, '') // Remove plural 's'
+    /** @type {Record<string, number>} */
     const msMap = {
       second: 1000,
       minute: 60000,
@@ -138,7 +148,7 @@ function parseInterval(intervalStr, fromDate = new Date()) {
 
 /**
  * Parse a timeout value into a Date
- * @param {String|Number} timeout - Timeout value
+ * @param {QuestTimeout} timeout - Timeout value
  * @param {Date} fromDate - Calculate from this date
  * @returns {Date|null} Next run time or null
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * sails-hook-quest
  *
@@ -10,12 +12,34 @@ const executor = require('./core/executor')
 const loader = require('./core/loader')
 const jobControl = require('./core/job-control')
 
-module.exports = function defineQuestHook(sails) {
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').QuestApi} QuestApi */
+/** @typedef {import('./types').QuestConfig} QuestConfig */
+/** @typedef {import('./types').QuestContext} QuestContext */
+/** @typedef {import('./types').QuestExecutableJob} QuestExecutableJob */
+/** @typedef {import('./types').QuestJobsMap} QuestJobsMap */
+/** @typedef {import('./types').QuestNamedJobDefinition} QuestNamedJobDefinition */
+/** @typedef {import('./types').QuestRunningMap} QuestRunningMap */
+/** @typedef {import('./types').QuestSailsApp} QuestSailsApp */
+/** @typedef {import('./types').QuestSailsHook} QuestSailsHook */
+/** @typedef {import('./types').QuestTimersMap} QuestTimersMap */
+
+/**
+ * Sails hook factory.
+ *
+ * @param {QuestSailsApp} sails
+ * @returns {QuestSailsHook}
+ */
+function defineQuestHook(sails) {
+  /** @type {QuestJobsMap} */
   const jobs = new Map()
+  /** @type {QuestTimersMap} */
   const timers = new Map()
+  /** @type {QuestRunningMap} */
   const running = new Map()
 
   // Create context object that will be passed to modules
+  /** @type {QuestContext} */
   const context = {
     jobs,
     timers,
@@ -56,15 +80,18 @@ module.exports = function defineQuestHook(sails) {
       sails.log.info('Initializing Quest job scheduler')
 
       sails.after('hook:orm:loaded', async () => {
+        const questConfig = sails.config.quest
+
         // Set up context with config
-        context.config = sails.config.quest
+        context.config = questConfig
         context.getNextRunTime = (job) =>
-          scheduler.getNextRunTime(job, sails.config.quest)
+          scheduler.getNextRunTime(job, questConfig)
         context.scheduleJob = (name) => jobControl.scheduleJob(name, context)
         context.executeJob = (name, customInputs) => {
           const job = jobs.get(name)
           if (!job) {
             // Try to run as a regular script without quest config
+            /** @type {QuestExecutableJob} */
             const minimalJob = {
               name,
               withoutOverlapping: false,
@@ -76,15 +103,16 @@ module.exports = function defineQuestHook(sails) {
         }
 
         // Load jobs from scripts and config
-        await loader.loadJobs(sails.config.quest, jobs)
+        await loader.loadJobs(questConfig, jobs)
 
         // Start all jobs if autoStart is enabled
-        if (sails.config.quest.autoStart) {
+        if (questConfig.autoStart) {
           await jobControl.startJobs(null, context)
         }
 
         // Expose the Quest API
-        sails.quest = {
+        /** @type {QuestApi} */
+        const questApi = {
           // Core job control
           start: (jobNames) => jobControl.startJobs(jobNames, context),
           stop: (jobNames) => jobControl.stopJobs(jobNames, context),
@@ -92,12 +120,14 @@ module.exports = function defineQuestHook(sails) {
             jobControl.runJobs(jobNames, inputs, context),
           add: (jobDefs) => {
             const defs = Array.isArray(jobDefs) ? jobDefs : [jobDefs]
+            /** @type {string[]} */
             const added = []
             for (const def of defs) {
+              /** @type {QuestNamedJobDefinition} */
               const job = typeof def === 'string' ? { name: def } : def
-              loader.addJobDefinition(job, jobs, context.config)
+              loader.addJobDefinition(job, jobs, context.config || {})
               added.push(job.name)
-              if (context.config.autoStart) {
+              if (context.config?.autoStart) {
                 jobControl.scheduleJob(job.name, context)
               }
             }
@@ -127,6 +157,7 @@ module.exports = function defineQuestHook(sails) {
           resume: (name) => jobControl.resumeJob(name, jobs)
         }
 
+        sails.quest = questApi
         sails.log.info(`Quest started with ${jobs.size} scheduled job(s)`)
       })
 
@@ -138,3 +169,5 @@ module.exports = function defineQuestHook(sails) {
     }
   }
 }
+
+module.exports = defineQuestHook

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,227 @@
+/**
+ * Shared TypeScript-consumable JSDoc typedefs for Quest's public API.
+ *
+ * These comments are intentionally colocated with the JavaScript source so JSDoc
+ * stays the source of truth for editor autocomplete and local type checks.
+ *
+ * @typedef {Record<string, any>} AnyRecord
+ *
+ * @typedef {string | number | boolean | null} JsonPrimitive
+ *
+ * @typedef {JsonPrimitive | any[] | AnyRecord} JsonValue
+ *
+ * @typedef {string | number} QuestInterval
+ *
+ * @typedef {string | number | false} QuestTimeout
+ *
+ * @typedef {string | number | Date} QuestDateInput
+ *
+ * @typedef {Record<string, any>} QuestCronOptions
+ *
+ * @typedef {{
+ *   defaultsTo?: any,
+ *   type?: string,
+ *   description?: string,
+ *   required?: boolean,
+ *   allowNull?: boolean,
+ *   [key: string]: any,
+ * }} QuestMachineInputDefinition
+ *
+ * @typedef {Record<string, QuestMachineInputDefinition>} QuestMachineInputs
+ *
+ * @typedef {{
+ *   name?: string,
+ *   friendlyName?: string,
+ *   description?: string,
+ *   interval?: QuestInterval,
+ *   timeout?: QuestTimeout,
+ *   cron?: string,
+ *   cronOptions?: QuestCronOptions,
+ *   date?: QuestDateInput,
+ *   timezone?: string,
+ *   inputs?: AnyRecord,
+ *   scriptInputs?: AnyRecord,
+ *   withoutOverlapping?: boolean,
+ *   paused?: boolean,
+ *   [key: string]: any,
+ * }} QuestJobDefinition
+ *
+ * @typedef {QuestJobDefinition & { name: string }} QuestNamedJobDefinition
+ *
+ * @typedef {string | QuestNamedJobDefinition} QuestJobDefinitionInput
+ *
+ * @typedef {{
+ *   name: string,
+ *   friendlyName: string,
+ *   description?: string,
+ *   interval?: QuestInterval,
+ *   timeout?: QuestTimeout,
+ *   cron?: string,
+ *   cronOptions?: QuestCronOptions,
+ *   date?: QuestDateInput,
+ *   timezone?: string,
+ *   inputs: AnyRecord,
+ *   scriptInputs: AnyRecord,
+ *   paused: boolean,
+ *   withoutOverlapping: boolean,
+ * }} QuestJob
+ *
+ * @typedef {{
+ *   name: string,
+ *   inputs?: AnyRecord,
+ *   scriptInputs?: AnyRecord,
+ *   paused?: boolean,
+ *   withoutOverlapping?: boolean,
+ * }} QuestExecutableJob
+ *
+ * @typedef {{
+ *   friendlyName?: string,
+ *   description?: string,
+ *   quest?: QuestJobDefinition,
+ *   inputs?: QuestMachineInputs,
+ *   fn?: Function,
+ *   [key: string]: any,
+ * }} QuestScriptDefinition
+ *
+ * @typedef {string | string[] | null | undefined} QuestJobNameInput
+ *
+ * @typedef {{
+ *   autoStart?: boolean,
+ *   timezone?: string,
+ *   withoutOverlapping?: boolean,
+ *   sailsPath?: string,
+ *   environment?: string,
+ *   scriptsDir?: string,
+ *   appPath?: string,
+ *   jobs?: QuestJobDefinitionInput[],
+ *   [key: string]: any,
+ * }} QuestConfig
+ *
+ * @typedef {{
+ *   skipped: true,
+ *   reason: 'already_running' | 'paused',
+ * }} QuestSkippedResult
+ *
+ * @typedef {{
+ *   success: true,
+ *   duration: number,
+ * }} QuestSuccessResult
+ *
+ * @typedef {QuestSkippedResult | QuestSuccessResult} QuestExecutionResult
+ *
+ * @typedef {{
+ *   name: string,
+ *   inputs: AnyRecord,
+ *   timestamp: Date,
+ * }} QuestJobStartEvent
+ *
+ * @typedef {{
+ *   name: string,
+ *   inputs: AnyRecord,
+ *   duration: number,
+ *   timestamp: Date,
+ * }} QuestJobCompleteEvent
+ *
+ * @typedef {{
+ *   message: string,
+ *   code?: number | null,
+ *   stack?: string,
+ * }} QuestJobErrorDetails
+ *
+ * @typedef {{
+ *   name: string,
+ *   inputs: AnyRecord,
+ *   error: QuestJobErrorDetails,
+ *   duration: number,
+ *   timestamp: Date,
+ * }} QuestJobErrorEvent
+ *
+ * @typedef {{
+ *   start(jobNames?: QuestJobNameInput): Promise<void>,
+ *   stop(jobNames?: QuestJobNameInput): void,
+ *   run(jobNames?: QuestJobNameInput, inputs?: AnyRecord): Promise<QuestExecutionResult[]>,
+ *   add(jobDefs: QuestJobDefinitionInput | QuestJobDefinitionInput[]): string[],
+ *   remove(jobNames: QuestJobNameInput): string[],
+ *   jobs: QuestJob[],
+ *   list(): QuestJob[],
+ *   get(name: string): QuestJob | undefined,
+ *   isRunning(name: string): boolean,
+ *   pause(name: string): boolean,
+ *   resume(name: string): boolean,
+ * }} QuestApi
+ *
+ * @typedef {Map<string, QuestJob>} QuestJobsMap
+ *
+ * @typedef {Map<string, ReturnType<typeof setTimeout>>} QuestTimersMap
+ *
+ * @typedef {Map<string, number>} QuestRunningMap
+ *
+ * @typedef {{
+ *   jobs: QuestJobsMap,
+ *   timers: QuestTimersMap,
+ *   running: QuestRunningMap,
+ *   config: QuestConfig | null,
+ *   scheduleJob: ((name: string) => void) | null,
+ *   executeJob: ((name: string, customInputs?: AnyRecord) => Promise<QuestExecutionResult>) | null,
+ *   getNextRunTime: ((job: QuestJob) => Date | null) | null,
+ * }} QuestContext
+ *
+ * @typedef {{
+ *   jobs?: QuestJobsMap,
+ *   timers?: QuestTimersMap,
+ *   getNextRunTime?: (job: QuestJob) => Date | null,
+ *   executeJob?: (name: string, customInputs?: AnyRecord) => Promise<QuestExecutionResult>,
+ * }} QuestScheduleContext
+ *
+ * @typedef {{
+ *   jobs?: QuestJobsMap,
+ *   scheduleJob?: (name: string) => void,
+ * }} QuestStartContext
+ *
+ * @typedef {{
+ *   jobs?: QuestJobsMap,
+ *   timers?: QuestTimersMap,
+ * }} QuestStopContext
+ *
+ * @typedef {{
+ *   jobs?: QuestJobsMap,
+ *   executeJob?: (name: string, customInputs?: AnyRecord) => Promise<QuestExecutionResult>,
+ * }} QuestRunContext
+ *
+ * @typedef {{
+ *   running?: QuestRunningMap,
+ *   config?: QuestConfig | null,
+ * }} QuestExecutorContext
+ *
+ * @typedef {{
+ *   info(...args: any[]): void,
+ *   warn(...args: any[]): void,
+ *   error(...args: any[]): void,
+ *   verbose(...args: any[]): void,
+ *   [key: string]: any,
+ * }} QuestLogger
+ *
+ * @typedef {{
+ *   config: {
+ *     quest: QuestConfig,
+ *     [key: string]: any,
+ *   },
+ *   log: QuestLogger,
+ *   after(eventName: string, handler: Function): void,
+ *   on(eventName: string, handler: Function): void,
+ *   emit(eventName: 'quest:job:start', payload: QuestJobStartEvent): void,
+ *   emit(eventName: 'quest:job:complete', payload: QuestJobCompleteEvent): void,
+ *   emit(eventName: 'quest:job:error', payload: QuestJobErrorEvent): void,
+ *   emit(eventName: string, payload?: any): void,
+ *   quest?: QuestApi,
+ *   [key: string]: any,
+ * }} QuestSailsApp
+ *
+ * @typedef {{
+ *   defaults: { quest: QuestConfig },
+ *   initialize(): Promise<void>,
+ *   [key: string]: any,
+ * }} QuestSailsHook
+ */
+
+module.exports = {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sails-hook-quest",
-  "version": "1.0.0",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sails-hook-quest",
-      "version": "1.0.0",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@breejs/later": "^4.2.0",
@@ -18,9 +18,11 @@
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",
         "@commitlint/config-conventional": "^19.5.0",
+        "@types/node": "^22.7.5",
         "husky": "^9.1.6",
         "lint-staged": "^15.2.10",
-        "prettier": "^3.3.3"
+        "prettier": "^3.3.3",
+        "typescript": "^5.6.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1954,7 +1956,6 @@
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "prettier --check .",
     "lint:fix": "prettier --write .",
+    "typecheck": "tsc -p jsconfig.json --noEmit",
     "prepare": "husky"
   },
   "repository": {
@@ -50,8 +51,10 @@
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
+    "@types/node": "^22.7.5",
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "typescript": "^5.6.2"
   }
 }

--- a/typecheck/public-api-smoke.js
+++ b/typecheck/public-api-smoke.js
@@ -1,0 +1,84 @@
+// @ts-check
+
+const defineQuestHook = require('../lib')
+const scheduler = require('../lib/core/scheduler')
+const loader = require('../lib/core/loader')
+
+/** @typedef {import('../lib/types').QuestSailsApp} QuestSailsApp */
+/** @typedef {import('../lib/types').QuestNamedJobDefinition} QuestNamedJobDefinition */
+
+/** @type {QuestSailsApp} */
+const sails = {
+  config: {
+    quest: {
+      autoStart: false,
+      timezone: 'UTC',
+      withoutOverlapping: true,
+      jobs: [
+        'cleanup-sessions',
+        {
+          name: 'health-check',
+          interval: '5 minutes',
+          inputs: { url: 'https://example.com/health' }
+        }
+      ]
+    }
+  },
+  log: {
+    info() {},
+    warn() {},
+    error() {},
+    verbose() {}
+  },
+  after(_eventName, handler) {
+    handler()
+  },
+  on() {},
+  emit() {}
+}
+
+const hook = defineQuestHook(sails)
+hook.defaults.quest.jobs.push({
+  name: 'daily-digest',
+  cron: '0 9 * * *',
+  timezone: 'Africa/Lagos'
+})
+
+/** @type {QuestNamedJobDefinition} */
+const dynamicJob = {
+  name: 'dynamic-report',
+  interval: '1 hour',
+  inputs: { format: 'csv' }
+}
+
+sails.quest?.add(dynamicJob)
+sails.quest?.start(['health-check', 'dynamic-report'])
+sails.quest?.run('health-check', { url: 'https://example.com/ping' })
+sails.quest?.pause('dynamic-report')
+sails.quest?.resume('dynamic-report')
+sails.quest?.remove(['dynamic-report'])
+
+const jobs = sails.quest?.list() || []
+const firstJob = jobs[0]
+if (firstJob) {
+  scheduler.getNextRunTime(firstJob, sails.config.quest)
+}
+
+loader.addJobDefinition(
+  {
+    name: 'warm-cache',
+    timeout: '10 minutes',
+    withoutOverlapping: false
+  },
+  new Map(),
+  sails.config.quest
+)
+
+// @ts-expect-error Job names must be strings or string arrays.
+sails.quest?.start(123)
+
+// @ts-expect-error Dynamic jobs need a string name when provided as objects.
+sails.quest?.add({ name: 123, interval: '5 minutes' })
+
+// @ts-expect-error Dynamic job objects need an explicit name.
+sails.quest?.add({ interval: '5 minutes' })


### PR DESCRIPTION
## Summary

- Added shared JSDoc typedefs for Quest config, jobs, API methods, lifecycle events, and internal runtime context.
- Added jsconfig-based checkJs coverage plus a public API smoke file with expected type failures.
- Annotated the existing hook/core modules while keeping runtime behavior effectively unchanged.

## Validation

- npm run typecheck
- npm run lint

Closes #8