### PR TITLE
fix: preserve failed job diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ module.exports.quest = {
   // Run jobs in console environment (minimal Sails lift)
   environment: 'console',
 
+  // Retain the final 64 KiB of child output when a job fails
+  diagnosticTailBytes: 64 * 1024,
+
   // Define additional jobs in config
   jobs: [
     {
@@ -215,9 +218,19 @@ Each event includes:
   inputs: { /* job inputs */ },
   timestamp: Date,
   duration: 1234,  // milliseconds (complete/error only)
-  error: { }       // error details (error event only)
+  error: {
+    message: 'Job "job-name" exited with code 1',
+    code: 1,
+    stack: 'Error: Job "job-name" exited with code 1\\n...',
+    diagnostic: 'The final bounded section of the child process output'
+  }
 }
 ```
+
+Job output still streams live to the parent process. On failure, Quest also
+includes a bounded diagnostic tail and a parent stack in the error event so
+observability tools can preserve the useful failure context without buffering
+the complete job log.
 
 ## Console Environment
 

--- a/lib/core/executor.js
+++ b/lib/core/executor.js
@@ -11,6 +11,8 @@ const fs = require('fs')
 const path = require('path')
 const { getGlobalSails } = require('./global-sails')
 
+const DEFAULT_DIAGNOSTIC_TAIL_BYTES = 64 * 1024
+
 /** @typedef {import('../types').AnyRecord} AnyRecord */
 /** @typedef {import('../types').QuestExecutableJob} QuestExecutableJob */
 /** @typedef {import('../types').QuestExecutionResult} QuestExecutionResult */
@@ -94,7 +96,7 @@ async function executeJob(name, job, customInputs = {}, context = {}) {
         sails.emit('quest:job:error', {
           name,
           inputs,
-          error: { message: error.message },
+          error: { message: error.message, stack: error.stack },
           duration: 0,
           timestamp: new Date()
         })
@@ -102,13 +104,31 @@ async function executeJob(name, job, customInputs = {}, context = {}) {
       return reject(error)
     }
 
+    const diagnosticTail = createDiagnosticTail(config.diagnosticTailBytes)
     const child = spawn(sailsPath, args, {
       cwd,
       env,
-      stdio: 'inherit'
+      stdio: ['inherit', 'pipe', 'pipe']
     })
 
-    child.on('exit', (code) => {
+    teeChildOutput(
+      child.stdout,
+      context.stdout || process.stdout,
+      diagnosticTail
+    )
+    teeChildOutput(
+      child.stderr,
+      context.stderr || process.stderr,
+      diagnosticTail
+    )
+
+    let settled = false
+
+    child.on('close', (code) => {
+      if (settled) {
+        return
+      }
+      settled = true
       const startTime = /** @type {number} */ (running.get(name))
       const duration = Date.now() - startTime
       running.delete(name)
@@ -139,7 +159,9 @@ async function executeJob(name, job, customInputs = {}, context = {}) {
             inputs,
             error: {
               message: error.message,
-              code
+              code,
+              stack: error.stack,
+              diagnostic: diagnosticTail.value()
             },
             duration,
             timestamp: new Date()
@@ -151,6 +173,10 @@ async function executeJob(name, job, customInputs = {}, context = {}) {
     })
 
     child.on('error', (err) => {
+      if (settled) {
+        return
+      }
+      settled = true
       const startTime = running.get(name) || Date.now()
       const duration = Date.now() - startTime
       running.delete(name)
@@ -164,7 +190,8 @@ async function executeJob(name, job, customInputs = {}, context = {}) {
           inputs,
           error: {
             message: err.message,
-            stack: err.stack
+            stack: err.stack,
+            diagnostic: diagnosticTail.value()
           },
           duration,
           timestamp: new Date()
@@ -173,6 +200,52 @@ async function executeJob(name, job, customInputs = {}, context = {}) {
 
       reject(err)
     })
+  })
+}
+
+/**
+ * Retain only the end of child output so a failed job can explain itself
+ * without buffering an unbounded process log.
+ *
+ * @param {number} [requestedMaxBytes]
+ */
+function createDiagnosticTail(requestedMaxBytes) {
+  const maxBytes =
+    Number.isFinite(requestedMaxBytes) && requestedMaxBytes > 0
+      ? Math.floor(requestedMaxBytes)
+      : DEFAULT_DIAGNOSTIC_TAIL_BYTES
+  let buffer = Buffer.alloc(0)
+
+  return {
+    /** @param {Buffer|string} chunk */
+    append(chunk) {
+      const incoming = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      buffer = Buffer.concat([buffer, incoming])
+      if (buffer.length > maxBytes) {
+        buffer = buffer.subarray(buffer.length - maxBytes)
+      }
+    },
+    value() {
+      return buffer.toString('utf8').trim()
+    }
+  }
+}
+
+/**
+ * Mirror child output to the parent while retaining a bounded diagnostic tail.
+ *
+ * @param {NodeJS.ReadableStream|null} source
+ * @param {NodeJS.WritableStream} destination
+ * @param {ReturnType<typeof createDiagnosticTail>} diagnosticTail
+ */
+function teeChildOutput(source, destination, diagnosticTail) {
+  if (!source) {
+    return
+  }
+
+  source.on('data', (chunk) => {
+    diagnosticTail.append(chunk)
+    destination.write(chunk)
   })
 }
 
@@ -201,5 +274,6 @@ function buildCommandArgs(scriptName, inputs = {}) {
 
 module.exports = {
   executeJob,
-  buildCommandArgs
+  buildCommandArgs,
+  createDiagnosticTail
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,6 +71,9 @@ function defineQuestHook(sails) {
         // Directory containing job scripts
         scriptsDir: 'scripts',
 
+        // Maximum child output retained on failure (live output remains unbounded)
+        diagnosticTailBytes: 64 * 1024,
+
         // Jobs defined in config
         jobs: []
       }

--- a/lib/types.js
+++ b/lib/types.js
@@ -93,6 +93,7 @@
  *   environment?: string,
  *   scriptsDir?: string,
  *   appPath?: string,
+ *   diagnosticTailBytes?: number,
  *   jobs?: QuestJobDefinitionInput[],
  *   [key: string]: any,
  * }} QuestConfig
@@ -126,6 +127,7 @@
  *   message: string,
  *   code?: number | null,
  *   stack?: string,
+ *   diagnostic?: string,
  * }} QuestJobErrorDetails
  *
  * @typedef {{
@@ -191,6 +193,8 @@
  * @typedef {{
  *   running?: QuestRunningMap,
  *   config?: QuestConfig | null,
+ *   stdout?: NodeJS.WritableStream,
+ *   stderr?: NodeJS.WritableStream,
  * }} QuestExecutorContext
  *
  * @typedef {{

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "husky": "^9.1.6",
         "lint-staged": "^15.2.10",
         "prettier": "^3.3.3",
+        "sounding": "^0.2.0",
         "typescript": "^5.6.2"
       }
     },
@@ -1841,6 +1842,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/sounding": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sounding/-/sounding-0.2.0.tgz",
+      "integrity": "sha512-Zr+V5XgyuEHuNEqmJbHPKptr3T1ldOFwjZFFKgNcyDxEPzOSEm7dEEznIb52AFHeQEu3N5+Mc80QG/9HxbQlGQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "plugins/*"
+      ],
+      "bin": {
+        "sounding": "bin/sounding.js"
       }
     },
     "node_modules/split2": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Elegant job scheduling for Sails.js applications with human-readable intervals, cron expressions, and full Sails context",
   "main": "lib/index.js",
   "scripts": {
-    "test": "node --test test/*.test.js",
+    "test": "sounding test",
     "lint": "prettier --check .",
     "lint:fix": "prettier --write .",
     "typecheck": "tsc -p jsconfig.json --noEmit",
@@ -56,6 +56,7 @@
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
     "prettier": "^3.3.3",
+    "sounding": "^0.2.0",
     "typescript": "^5.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Elegant job scheduling for Sails.js applications with human-readable intervals, cron expressions, and full Sails context",
   "main": "lib/index.js",
   "scripts": {
+    "test": "node --test test/*.test.js",
     "lint": "prettier --check .",
     "lint:fix": "prettier --write .",
     "typecheck": "tsc -p jsconfig.json --noEmit",

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -1,14 +1,29 @@
-const assert = require('node:assert/strict')
 const { EventEmitter } = require('node:events')
 const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
 const { Writable } = require('node:stream')
-const test = require('node:test')
+const { createRuntime, createTestApi } = require('sounding')
 
 const { createDiagnosticTail, executeJob } = require('../lib/core/executor')
 
-test('failed jobs keep live output and emit bounded diagnostics', async (t) => {
+const sails = new EventEmitter()
+sails.config = {
+  appPath: process.cwd(),
+  environment: 'test',
+  datastores: {}
+}
+sails.hooks = {}
+sails.helpers = {}
+sails.models = {}
+sails.log = { info() {}, warn() {}, error() {}, verbose() {} }
+
+const test = createTestApi({ runtime: createRuntime(sails) })
+
+test('failed jobs keep live output and emit bounded diagnostics', async ({
+  expect,
+  t
+}) => {
   const appPath = fs.mkdtempSync(path.join(os.tmpdir(), 'quest-diagnostics-'))
   const scriptsPath = path.join(appPath, 'scripts')
   const runnerPath = path.join(appPath, 'fake-sails')
@@ -26,8 +41,6 @@ test('failed jobs keep live output and emit bounded diagnostics', async (t) => {
   fs.chmodSync(runnerPath, 0o755)
 
   const previousSails = global.sails
-  const sails = new EventEmitter()
-  sails.log = { info() {}, warn() {}, error() {}, verbose() {} }
   global.sails = sails
 
   let liveOutput = ''
@@ -46,8 +59,9 @@ test('failed jobs keep live output and emit bounded diagnostics', async (t) => {
     fs.rmSync(appPath, { recursive: true, force: true })
   })
 
-  await assert.rejects(
-    executeJob(
+  let executionError
+  try {
+    await executeJob(
       'send-issue-notifications',
       { name: 'send-issue-notifications' },
       {},
@@ -56,22 +70,26 @@ test('failed jobs keep live output and emit bounded diagnostics', async (t) => {
         stdout: output,
         stderr: output
       }
-    ),
-    /exited with code 1/
-  )
+    )
+  } catch (error) {
+    executionError = error
+  }
 
   const event = await failure
-  assert.match(liveOutput, /Preparing notifications/)
-  assert.match(liveOutput, /database exploded/)
-  assert.match(event.error.diagnostic, /sendIssueNotifications/)
-  assert.match(event.error.stack, /executor\.js/)
+  expect(executionError.message).toContain('exited with code 1')
+  expect(liveOutput).toContain('Preparing notifications')
+  expect(liveOutput).toContain('database exploded')
+  expect(event.error.diagnostic).toContain('sendIssueNotifications')
+  expect(event.error.stack).toContain('executor.js')
 })
 
-test('diagnostic tails discard old output at the configured byte limit', () => {
+test('diagnostic tails discard old output at the configured byte limit', ({
+  expect
+}) => {
   const tail = createDiagnosticTail(12)
   tail.append('discard-this-')
   tail.append('keep-this')
 
-  assert.equal(Buffer.byteLength(tail.value()), 12)
-  assert.equal(tail.value(), 'is-keep-this')
+  expect(Buffer.byteLength(tail.value())).toBe(12)
+  expect(tail.value()).toBe('is-keep-this')
 })

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -1,0 +1,77 @@
+const assert = require('node:assert/strict')
+const { EventEmitter } = require('node:events')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { Writable } = require('node:stream')
+const test = require('node:test')
+
+const { createDiagnosticTail, executeJob } = require('../lib/core/executor')
+
+test('failed jobs keep live output and emit bounded diagnostics', async (t) => {
+  const appPath = fs.mkdtempSync(path.join(os.tmpdir(), 'quest-diagnostics-'))
+  const scriptsPath = path.join(appPath, 'scripts')
+  const runnerPath = path.join(appPath, 'fake-sails')
+  fs.mkdirSync(scriptsPath)
+  fs.writeFileSync(path.join(scriptsPath, 'send-issue-notifications.js'), '')
+  fs.writeFileSync(
+    runnerPath,
+    [
+      '#!/usr/bin/env node',
+      "process.stdout.write('Preparing notifications\\n')",
+      "process.stderr.write('Error: database exploded\\n    at sendIssueNotifications (/app/scripts/send-issue-notifications.js:12:3)\\n')",
+      'process.exitCode = 1'
+    ].join('\n')
+  )
+  fs.chmodSync(runnerPath, 0o755)
+
+  const previousSails = global.sails
+  const sails = new EventEmitter()
+  sails.log = { info() {}, warn() {}, error() {}, verbose() {} }
+  global.sails = sails
+
+  let liveOutput = ''
+  const output = new Writable({
+    write(chunk, encoding, callback) {
+      liveOutput += chunk.toString()
+      callback()
+    }
+  })
+  const failure = new Promise((resolve) =>
+    sails.once('quest:job:error', resolve)
+  )
+
+  t.after(() => {
+    global.sails = previousSails
+    fs.rmSync(appPath, { recursive: true, force: true })
+  })
+
+  await assert.rejects(
+    executeJob(
+      'send-issue-notifications',
+      { name: 'send-issue-notifications' },
+      {},
+      {
+        config: { appPath, sailsPath: runnerPath, diagnosticTailBytes: 1024 },
+        stdout: output,
+        stderr: output
+      }
+    ),
+    /exited with code 1/
+  )
+
+  const event = await failure
+  assert.match(liveOutput, /Preparing notifications/)
+  assert.match(liveOutput, /database exploded/)
+  assert.match(event.error.diagnostic, /sendIssueNotifications/)
+  assert.match(event.error.stack, /executor\.js/)
+})
+
+test('diagnostic tails discard old output at the configured byte limit', () => {
+  const tail = createDiagnosticTail(12)
+  tail.append('discard-this-')
+  tail.append('keep-this')
+
+  assert.equal(Buffer.byteLength(tail.value()), 12)
+  assert.equal(tail.value(), 'is-keep-this')
+})


### PR DESCRIPTION
Quest currently streams child output live and then discards it, so consumers receive only an exit code when a job fails.

This keeps the existing live output while retaining a configurable, bounded diagnostic tail. Failure events now include that diagnostic plus a parent stack, and missing-script failures include their stack as well.

Validation:
- npm test
- npm run lint
- npm run typecheck

Fixes #11